### PR TITLE
Allow articles to be placed in 1/4 width homepage blocks

### DIFF
--- a/src/components/ContentTypesBlock.tsx
+++ b/src/components/ContentTypesBlock.tsx
@@ -71,6 +71,7 @@ function renderArticle(props: IProps) {
       title={props.block.overrideTitle || article.title}
       image={article.featuredImage}
       description={props.block.overrideDescription || article.shortDescription}
+      aspectRatio={props.aspectRatio}
     />
   );
 }
@@ -121,6 +122,7 @@ function renderEvent(props: IProps) {
       title={props.block.overrideTitle || event.title}
       description={props.block.overrideDescription || event.shortDescription}
       image={props.block.object.featuredImage}
+      aspectRatio={props.aspectRatio}
     />
   );
 }

--- a/src/components/ContentTypesBlock.tsx
+++ b/src/components/ContentTypesBlock.tsx
@@ -20,6 +20,7 @@ interface IProps {
     object: any;
   };
   size: 1 | 2 | 3;
+  aspectRatio?: AspectRatio;
 }
 
 // TODO: move to a utils thing or i18n file
@@ -82,6 +83,7 @@ function renderShow(props: IProps) {
       innerClassName={articleStyles}
       link={`/shows/${show.slug}`}
       backgroundColor={`#${getShowColourHexString(show)}`}
+      aspectRatio={props.aspectRatio}
     >
       <ShowBlockContainer size={props.size}>
         <ShowCover size={props.size}>

--- a/src/components/HomepageBlock.tsx
+++ b/src/components/HomepageBlock.tsx
@@ -75,6 +75,7 @@ interface IBlockProps {
   description?: string;
   size: 1 | 2 | 3;
   children?: any;
+  aspectRatio?: AspectRatio;
 }
 
 export function Block(props: IBlockProps) {
@@ -90,7 +91,7 @@ export function Block(props: IBlockProps) {
         <OneImage
           className={imageScaleStyle}
           src={props.image.resource}
-          aspectRatio={AspectRatio.rPanovision70}
+          aspectRatio={props.aspectRatio || AspectRatio.rPanovision70}
           alt=""
         />
       )}

--- a/src/containers/Home.tsx
+++ b/src/containers/Home.tsx
@@ -8,6 +8,7 @@ import { Flex, Box } from 'grid-emotion';
 import { HomepageBlock } from '../components/ContentTypesBlock';
 import { OnAirBlock } from '../components/OnAirBlock';
 import Spinner from '../components/Spinner';
+import { AspectRatio } from "../components/OneImage";
 
 interface IProps {
   data: any;
@@ -82,16 +83,16 @@ function renderBlocks(props: IProps) {
       {hasQuarters && (
         <Flex mx={-2} wrap>
           <Box width={[1, 1 / 2, 1 / 4]} px={gutterLeft} mb={gutter}>
-            <HomepageBlock block={byPosition.FOURTH_1} size={3} />
+            <HomepageBlock block={byPosition.FOURTH_1} size={3} aspectRatio={AspectRatio.r1by1} />
           </Box>
           <Box width={[1, 1 / 2, 1 / 4]} px={gutterLeft} mb={gutter}>
-            <HomepageBlock block={byPosition.FOURTH_2} size={3} />
+            <HomepageBlock block={byPosition.FOURTH_2} size={3} aspectRatio={AspectRatio.r1by1} />
           </Box>
           <Box width={[1, 1 / 2, 1 / 4]} px={gutterLeft} mb={gutter}>
-            <HomepageBlock block={byPosition.FOURTH_3} size={3} />
+            <HomepageBlock block={byPosition.FOURTH_3} size={3} aspectRatio={AspectRatio.r1by1} />
           </Box>
           <Box width={[1, 1 / 2, 1 / 4]} px={gutterLeft} mb={gutter}>
-            <HomepageBlock block={byPosition.FOURTH_4} size={3} />
+            <HomepageBlock block={byPosition.FOURTH_4} size={3} aspectRatio={AspectRatio.r1by1} />
           </Box>
         </Flex>
       )}


### PR DESCRIPTION
Small patch which allows articles and events to be placed in one of the quarter-width blocks on the homepage.

Possible additions to this patch:
* Let shows be placed in the upper blocks (as I'm writing this, I can see the changes that should allow this...)
* Unify look of articles vs shows in quarter-width blocks, article images fill the block whereas show images have a border