### PR TITLE
Fix issues with layered rendering on Safari

### DIFF
--- a/src/components/Player.tsx
+++ b/src/components/Player.tsx
@@ -34,7 +34,9 @@ const Player: React.FC<IProps> = () => {
 
   return (
     <div className="Player">
-      {show.cover.resource ? <img className="Player__img-back" src={'https://urf.imgix.net/' + show.cover.resource + "?w=200&h=200&q=50&auto=format"} /> : null}
+      <div className="Player__img-container">
+        {show.cover.resource ? <img className="Player__img-back" src={'https://urf.imgix.net/' + show.cover.resource + "?w=200&h=200&q=50&auto=format"} /> : null}
+      </div>
       <div className="Player__container">
         <div className="Player__content Player__section">
           <div className="Player__show-cover">

--- a/src/css/components/Page.css
+++ b/src/css/components/Page.css
@@ -1,7 +1,6 @@
 .Page {
   background-color: #f6f1f1;
   position: relative;
-  z-index: var(--layer-page);
   margin-top: var(--header-height);
   min-height: calc(100vh - var(--header-height));
   box-sizing: border-box;

--- a/src/css/components/Player.css
+++ b/src/css/components/Player.css
@@ -8,7 +8,6 @@
   color: #ffffff;
   box-shadow: 0 0 16px 0 rgba(30, 30, 30, 0.3);
   z-index: var(--layer-player);
-  overflow: hidden;
 
   &__audio {
     width: 100%;
@@ -28,6 +27,13 @@
     align-content: center;
     align-items: center;
     z-index: 1;
+  }
+
+  &__img-container {
+    position: absolute;
+    overflow: hidden;
+    height: 100%;
+    width: 100%;
   }
 
    &__img-back {


### PR DESCRIPTION
Safari has some odd behaviours where `position: fixed` and `z-index` are mixed, and this was causing several problems with the Player component styling:
* Player bar was hidden behind the navigation bar
* Stream selector list was cut off by the player bar

This PR fixes both of these issues.