### PR TITLE
Fix stream metadata not being resolved when only one Icecast source

### DIFF
--- a/src/utils/schedule.ts
+++ b/src/utils/schedule.ts
@@ -306,11 +306,16 @@ export function resolveStreamOrder(streams: Array<any>): Promise<any> {
         .then((res) => res.json())
         .then((data: any) => {
           let info = data.icestats;
+          let source = info.source;
+
+          if (Array.isArray(source)) {
+            source = info.source[0];
+          }
 
           return { stream,
             bed: asleep,
-            offline: info.source.length <= 0,
-            description: (info.source[0] ? info.source[0].server_description : null)
+            offline: source == null,
+            description: (source ? source.server_description : null)
           };
         })
         .catch(() => {


### PR DESCRIPTION
Turns out that Icecast's JSON API is a little weird - if there's only
one source, it returns the source as a plain object, rather than
wrapping it in a single-element array. To fix, we just check if
`info.source` is an array, and behave accordingly.